### PR TITLE
CardInfo Title&Description HTML Fix

### DIFF
--- a/backend/src/feedGeneration/CardInfo.py
+++ b/backend/src/feedGeneration/CardInfo.py
@@ -47,8 +47,15 @@ def getCardData(link) -> dict:
             imageLink = meta_tag_image.get('content')
 
             articleTitleFiltered = meta_tag_title.get('content')
+            titleSoup = BeautifulSoup(articleTitleFiltered)
+            articleTitleFiltered = titleSoup.get_text()
+
 
             articleDescriptionFiltered = meta_tag_description.get('content')
+            descriptionSoup = BeautifulSoup(articleDescriptionFiltered)
+            articleDescriptionFiltered = descriptionSoup.get_text()
+
+            
 
             #Creating the return dictonary if all actions worked.
             out = {
@@ -73,8 +80,14 @@ def getCardData(link) -> dict:
             imageLink = meta_tag_image.get('content')
 
             articleTitleFiltered = meta_tag_title.get('content')
+            titleSoup = BeautifulSoup(articleTitleFiltered)
+            articleTitleFiltered = titleSoup.get_text()
+
 
             articleDescriptionFiltered = meta_tag_description.get('content')
+            descriptionSoup = BeautifulSoup(articleDescriptionFiltered)
+            articleDescriptionFiltered = descriptionSoup.get_text()
+
 
             #Creating the return dictonary if all actions worked.
             out = {
@@ -94,9 +107,16 @@ def getCardData(link) -> dict:
             meta_tag_description = soup.find("meta", {"property": "og:description"})
 
             imageLink = meta_tag_image.get('content')
+            
             articleTitleFiltered = meta_tag_title.get('content')
+            titleSoup = BeautifulSoup(articleTitleFiltered)
+            articleTitleFiltered = titleSoup.get_text()
+
 
             articleDescriptionFiltered = meta_tag_description.get('content')
+            descriptionSoup = BeautifulSoup(articleDescriptionFiltered)
+            articleDescriptionFiltered = descriptionSoup.get_text()
+
             #Creating the return dictonary if all actions worked.
             out = {
                 "image": imageLink,


### PR DESCRIPTION
Yesterday I discovered that some article previews may have html script within it. Though this issue is rare, it's still possible as I discovered yesterday, so I applied Beautiful Soup on the content of the title and description, and if it contains any HTML, it will parse that out and obtain solely the text.

Attached is an image of what I mean:

![RockwellIssue](https://user-images.githubusercontent.com/49537223/150417527-a0c7aa53-d44b-4bc7-b978-c12aba107554.png)
